### PR TITLE
Fix CMAF computation when doing framerate conversion. Optimize x264 settings more. Add h264_zerolatency setting

### DIFF
--- a/webrtc-vmaf.py
+++ b/webrtc-vmaf.py
@@ -37,7 +37,7 @@ def main():
                                         width=args.width,
                                         height=args.height,
                                         )
-            print(f"  {path.basename(input)}: {score} \tfps: {math.floor(fps)}")
+            print(f"  {path.basename(input)}: {score} \tfps: {math.floor(fps)}\t bitrate: {out_bitrate/1000}kb/s")
             score_total += score
             fps_total += fps
             bitrate_total += out_bitrate
@@ -214,8 +214,6 @@ def encode_file(input, output, codec, width, height, bitrate, framerate):
     else:
         raise Exception(
             "Unsupported codec. Please use one of these: 'h264', 'vp8', 'vp9', 'av1'")
-
-    print(f'running command {" ".join(command)}')
 
     command.append(output)
 

--- a/webrtc-vmaf.py
+++ b/webrtc-vmaf.py
@@ -147,7 +147,7 @@ def encode_file(input, output, codec, width, height, bitrate, framerate):
             '-rc-lookahead', '0',
             '-profile:v', 'baseline',
             '-maxrate', bitrate_str,
-            '-bufsize', f'{2 * bitrate}K',
+            '-bufsize', f'{bitrate}K',
         ])
     elif codec == 'h264_zerolatency':
         # libwebrtc bundles OpenH264, which isn't available with FFmpeg
@@ -158,7 +158,7 @@ def encode_file(input, output, codec, width, height, bitrate, framerate):
             '-tune', 'zerolatency',
             '-profile:v', 'baseline',
             '-maxrate', bitrate_str,
-            '-bufsize', f'{2 * bitrate}K',
+            '-bufsize', f'{bitrate}K',
         ])
     elif codec == 'vp8':
         command.extend([
@@ -172,6 +172,7 @@ def encode_file(input, output, codec, width, height, bitrate, framerate):
             '-cpu-used', '-6',
             '-qmax', '52',
             '-qmin', '2',
+            '-bufsize', f'{bitrate}K',
         ])
     elif codec == 'vp9':
         command.extend([

--- a/webrtc-vmaf.py
+++ b/webrtc-vmaf.py
@@ -120,7 +120,7 @@ def encode_file(input, output, codec, width, height, bitrate, framerate):
         '-i', input,
         '-b:v', bitrate_str,
         '-filter:v', filters,
-        '-threads', '8',
+        '-threads', '7',
         '-an',  # This option tells FFmpeg to discard any audio
         '-y',
         '-loglevel', 'error',
@@ -136,9 +136,18 @@ def encode_file(input, output, codec, width, height, bitrate, framerate):
         command.extend([
             'libx264',
             '-preset', 'veryfast',
+            '-profile:v', 'baseline',
+        ])
+    elif codec == 'h264_zerolatency':
+        # libwebrtc bundles OpenH264, which isn't available with FFmpeg
+        # using libx264 as a substitute
+        command.extend([
+            'libx264',
+            '-preset', 'veryfast',
             '-tune', 'zerolatency',
             '-profile:v', 'baseline',
         ])
+
     elif codec == 'vp8':
         command.extend([
             'libvpx',
@@ -204,7 +213,7 @@ def compute_vmaf(input, output, width, height, framerate):
         'ffmpeg',
         '-i', input,
         '-i', output,
-        '-filter_complex', f'[0:v]scale={width}:{height}:flags=bicubic,framerate={framerate},setpts=PTS-STARTPTS[ref];[1:v]scale={width}:{height}:flags=bicubic,framerate={framerate},setpts=PTS-STARTPTS[distorted];[distorted][ref]libvmaf=n_threads=8',
+        '-filter_complex', f'[0:v]fps={framerate},scale={width}x{height}:flags=bicubic,settb=AVTB,setpts=PTS-STARTPTS[ref];[1:v]fps={framerate},settb=AVTB,setpts=PTS-STARTPTS[distorted];[distorted][ref]libvmaf=n_threads=8',
         '-f', 'null',
         '-',
     ]


### PR DESCRIPTION
This PR makes sure we use the "fps" ffmpeg filter both when transcoding and doing CMAF computation. Currently, the framerate filter is used during CMAF computation. framerate interpolates a frame rather than doing simple frame dropping or duplication. This means that CMAF computation was using a wrong reference frame.

x264 settings are also slightly optimized here, and a specific "zerolatency" setting was added.